### PR TITLE
add mcp tools from hono routes

### DIFF
--- a/src/hono/index.ts
+++ b/src/hono/index.ts
@@ -1,3 +1,4 @@
 export { validator, type Options } from "./middleware";
 export { openAPISpecs, describeRoute } from "./openapi/openapi";
 export { schemaToSpec } from "./openapi/utils";
+export { info, type RouteInfo, type InfoOptions } from "./info";

--- a/src/hono/info.spec.ts
+++ b/src/hono/info.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect, describe } from "bun:test";
+import { Hono } from "hono";
+import { validator as jsc } from "./middleware";
+import * as s from "../lib";
+import { describeRoute } from "./openapi/openapi";
+import { info } from "./info";
+
+describe("hono info", () => {
+   test("basic info", async () => {
+      const app = new Hono()
+         .get(
+            "/some",
+            describeRoute({
+               summary: "Some route",
+               description: "Some description",
+               tags: ["some"],
+            }),
+            jsc("query", s.object({ ok: s.boolean().optional() })),
+            async (c) => {
+               return c.json({ ok: true });
+            }
+         )
+         .get("/another", (c) => c.json({ ok: true }));
+
+      expect(JSON.parse(JSON.stringify(info(app)))).toEqual({
+         "/some": {
+            methods: ["GET"],
+            openAPI: {
+               paths: {
+                  "/some": {
+                     get: {
+                        responses: {},
+                        operationId: "getSome",
+                        summary: "Some route",
+                        description: "Some description",
+                        tags: ["some"],
+                        parameters: [
+                           {
+                              name: "ok",
+                              in: "query",
+                              required: undefined,
+                              description: undefined,
+                              schema: {
+                                 type: "boolean",
+                              },
+                           },
+                        ],
+                     },
+                  },
+               },
+            },
+            validation: {
+               query: {
+                  type: "object",
+                  properties: {
+                     ok: {
+                        type: "boolean",
+                     },
+                  },
+               },
+            },
+         },
+         "/another": {
+            methods: ["GET"],
+         },
+      });
+   });
+});

--- a/src/hono/info.ts
+++ b/src/hono/info.ts
@@ -1,0 +1,89 @@
+import type { Hono, ValidationTargets } from "hono";
+import { $symbol, type RouteHandler } from "./shared";
+import { registerPath } from "./openapi/utils";
+import type * as t from "./openapi/types";
+import type { JSONSchemaDefinition, ObjectSchema } from "jsonv-ts";
+import type { RouterRoute } from "hono/types";
+
+export type RouteInfo<Options extends InfoOptions = InfoOptions> = {
+   methods: string[];
+   openAPI?: Options extends { skipOpenAPI: true }
+      ? undefined
+      : Partial<t.Document>;
+   validation?: Partial<
+      Record<
+         keyof ValidationTargets,
+         Options extends { useSchemas: true }
+            ? ObjectSchema
+            : JSONSchemaDefinition
+      >
+   >;
+   handler?: RouterRoute["handler"];
+} & (Options extends { extra: (route: RouterRoute) => infer T } ? T : {});
+
+export type InfoOptions = {
+   // returns schema instance instead of JSON schema definition
+   useSchemas?: boolean;
+   // skip openapi extraction for this route
+   skipOpenAPI?: boolean;
+   // extra properties to add to the route info
+   extra?: (route: RouterRoute) => Record<string, any>;
+};
+
+export function info<Options extends InfoOptions = InfoOptions>(
+   hono: Hono<any>,
+   options?: Options
+) {
+   const routes: Record<string, RouteInfo<Options>> = {};
+
+   for (const route of hono.routes) {
+      const path = [route.basePath, route.path]
+         .filter(Boolean)
+         .join("/")
+         .replace(/\/+/g, "/");
+
+      if (!routes[path]) {
+         routes[path] = {
+            methods: [],
+         } as RouteInfo<Options>;
+      }
+
+      const method = route.method.toUpperCase();
+      routes[path].methods = Array.from(
+         new Set([...routes[path].methods, method])
+      );
+
+      // always take the last handler
+      if (route.handler) {
+         routes[path].handler = route.handler;
+      }
+
+      if ($symbol in route.handler) {
+         const routeHandler = route.handler[$symbol] as RouteHandler;
+         if (routeHandler) {
+            if (!options?.skipOpenAPI) {
+               if (!routes[path].openAPI) {
+                  routes[path].openAPI = {} as any;
+               }
+               registerPath(routes[path].openAPI as any, route, routeHandler);
+            }
+
+            if (routeHandler.type === "parameters") {
+               if (!routes[path].validation) {
+                  routes[path].validation = {};
+               }
+
+               if (!routes[path].validation[routeHandler.value.target]) {
+                  // @ts-expect-error
+                  routes[path].validation[routeHandler.value.target] =
+                     options?.useSchemas
+                        ? routeHandler.value.schema
+                        : routeHandler.value.schema.toJSON();
+               }
+            }
+         }
+      }
+   }
+
+   return routes;
+}

--- a/src/hono/middleware.spec.ts
+++ b/src/hono/middleware.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect, describe } from "bun:test";
 import { Hono } from "hono";
 import { validator as jsc } from "./middleware";
-//import { honoValidator as jsc } from "jsonv-ts/hono";
 import * as s from "../lib";
 import { expectTypeOf } from "expect-type";
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -49,6 +49,7 @@ export type {
    ValidationOptions,
 } from "./validation/validate";
 export { error, type ErrorDetail, valid, makeOpts } from "./utils/details";
+export { invariant, isSchema } from "./utils";
 export { type CoercionOptions } from "./validation/coerce";
 export {
    type ParseOptions,

--- a/src/lib/object/record.ts
+++ b/src/lib/object/record.ts
@@ -15,6 +15,9 @@ type RecordCoerced<AP extends Schema> = Simplify<
 
 export interface IRecordOptions extends ISchemaOptions {
    additionalProperties?: never;
+   maxProperties?: number;
+   minProperties?: number;
+   propertyNames?: Schema;
 }
 
 export class RecordSchema<

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,12 +1,12 @@
-import {
+import type {
    InitializeMessage,
-   LoggingMessage,
-   ResourcesReadMessage,
+   PingMessage,
+   ToolsListMessage,
+   ToolsCallMessage,
    ResourcesListMessage,
    ResourcesTemplatesListMessage,
-   type PingMessage,
-   type ToolsCallMessage,
-   type ToolsListMessage,
+   ResourcesReadMessage,
+   LoggingMessage,
 } from "./messages";
 import type {
    RpcMessage,
@@ -16,6 +16,7 @@ import type {
    TRpcResponse,
 } from "./rpc";
 import { protocolVersion } from "./server";
+import type { MaybePromise } from "./utils";
 
 export interface McpClientConfig {
    name?: string;
@@ -24,7 +25,10 @@ export interface McpClientConfig {
    url: string | URL;
    fetch?:
       | typeof fetch
-      | ((url: string | URL, options: RequestInit) => Promise<Response>);
+      | ((
+           url: string | RequestInfo | URL,
+           options?: RequestInit
+        ) => MaybePromise<Response>);
 }
 
 export class McpClient {

--- a/src/mcp/hono/mcp-features.middleware.spec.ts
+++ b/src/mcp/hono/mcp-features.middleware.spec.ts
@@ -1,0 +1,339 @@
+import { test, expect, describe } from "bun:test";
+import { Hono } from "hono";
+import { validator } from "../../hono";
+import { parse, s } from "../../lib";
+import {
+   getMcpFeatures,
+   mcpTool,
+   infoValidationTargetsToSchema,
+   payloadToValidationTargetPayload,
+   getMcpServer,
+   withMcp,
+} from "./mcp-features.middleware";
+import { Tool } from "../tool";
+import { McpClient } from "../client";
+import { mcp } from "./mcp.middleware";
+
+const call = async (tool: Tool, params: any) => {
+   const res = await tool.call(params, {}, new Request("http://localhost"));
+   return JSON.parse((res as any).text);
+};
+
+describe("mcp features", () => {
+   test("payloadToValidationTargetPayload", async () => {
+      const targets = {
+         query: s.object({ limit: s.number().optional() }),
+         params: s.object({ name: s.string() }),
+      };
+
+      const schema = infoValidationTargetsToSchema(targets);
+      expect(schema?.toJSON()).toEqual({
+         type: "object",
+         required: ["name"],
+         properties: {
+            limit: {
+               type: "number",
+               $target: "query",
+            },
+            name: {
+               type: "string",
+               $target: "params",
+            },
+         },
+      } as any);
+
+      const payload = {
+         limit: "1",
+         name: "foo",
+      };
+      const parsed = parse(schema!, payload);
+      expect(parsed).toEqual({
+         limit: 1,
+         name: "foo",
+      });
+
+      expect(payloadToValidationTargetPayload(parsed, schema!)).toEqual({
+         query: {
+            limit: 1,
+         },
+         params: {
+            name: "foo",
+         },
+      } as any);
+   });
+
+   test("extract an empty tool", async () => {
+      const hono = new Hono().get("/", mcpTool("get"), (c) =>
+         c.json({ ok: true })
+      );
+
+      const features = getMcpFeatures(hono);
+
+      expect(JSON.parse(JSON.stringify(features))).toEqual([
+         {
+            type: "tool",
+            tool: {
+               name: "get",
+               config: {},
+            },
+            path: "/",
+            info: {
+               methods: ["GET"],
+            },
+         },
+      ]);
+   });
+
+   test("extract a simple tool", async () => {
+      const hono = new Hono().get(
+         "/",
+         mcpTool("get"),
+         validator("query", s.object({ num: s.number() })),
+         (c) => c.json({ num: c.req.valid("query").num, hono: true })
+      );
+
+      const features = getMcpFeatures(hono);
+      const expected = {
+         type: "tool",
+         tool: {
+            name: "get",
+            config: {},
+         },
+         path: "/",
+         info: {
+            methods: ["GET"],
+            validation: {
+               query: {
+                  type: "object",
+                  properties: {
+                     num: {
+                        type: "number",
+                     },
+                  },
+                  required: ["num"],
+               },
+            },
+         },
+      };
+
+      expect(JSON.parse(JSON.stringify(features))).toEqual([expected]);
+   });
+
+   test("feature extraction", async () => {
+      const hono = new Hono()
+         .get("/", mcpTool("get"), (c) =>
+            c.json({ ok: true, message: "hi from get" })
+         )
+         .get(
+            "/another",
+            mcpTool("another"),
+            validator("query", s.object({ query: s.string() })),
+            (c) =>
+               c.json({
+                  ok: true,
+                  message: `query: ${c.req.valid("query").query}`,
+               })
+         )
+         .get(
+            "/path/:name",
+            mcpTool("path"),
+            validator("param", s.object({ name: s.string() })),
+            async (c) =>
+               c.json({ ok: true, message: `path: ${c.req.param("name")}` })
+         );
+
+      const features = getMcpFeatures(hono);
+      expect(JSON.parse(JSON.stringify(features))).toEqual([
+         {
+            type: "tool",
+            tool: {
+               name: "get",
+               config: {},
+            },
+            path: "/",
+            info: {
+               methods: ["GET"],
+            },
+         },
+         {
+            type: "tool",
+            tool: {
+               name: "another",
+               config: {},
+            },
+            path: "/another",
+            info: {
+               methods: ["GET"],
+               validation: {
+                  query: {
+                     type: "object",
+                     properties: {
+                        query: {
+                           type: "string",
+                        },
+                     },
+                     required: ["query"],
+                  },
+               },
+            },
+         },
+         {
+            type: "tool",
+            tool: {
+               name: "path",
+               config: {},
+            },
+            path: "/path/:name",
+            info: {
+               methods: ["GET"],
+               validation: {
+                  param: {
+                     type: "object",
+                     properties: {
+                        name: {
+                           type: "string",
+                        },
+                     },
+                     required: ["name"],
+                  },
+               },
+            },
+         },
+      ]);
+   });
+
+   test("multiple tools", async () => {
+      const hono = new Hono()
+         .get("/", mcpTool("get"), (c) =>
+            c.json({ ok: true, message: "hi from get" })
+         )
+         .get(
+            "/another",
+            mcpTool("another"),
+            validator("query", s.object({ query: s.string() })),
+            (c) =>
+               c.json({
+                  ok: true,
+                  message: `query: ${c.req.valid("query").query}`,
+               })
+         )
+         .get(
+            "/path/:name",
+            mcpTool("path"),
+            validator("param", s.object({ name: s.string() })),
+            async (c) => {
+               const name = c.req.valid("param").name;
+               if (name === "error") {
+                  return c.json(
+                     {
+                        ok: false,
+                        error: "error",
+                     },
+                     400
+                  );
+               }
+
+               return c.json({
+                  ok: true,
+                  message: `path: ${name}`,
+               });
+            }
+         );
+
+      const server = getMcpServer(hono);
+      const client = new McpClient({
+         url: "http://localhost/sse",
+         //fetch: new Hono().use(mcp(server)).request,
+         fetch: withMcp(hono).request,
+      });
+      expect(server.tools.length).toBe(3);
+
+      expect(
+         await client.listTools().then((r) => r!.tools.map((t) => t.name))
+      ).toEqual(["get", "another", "path"]);
+
+      expect(
+         await client.callTool({
+            name: "get",
+         })
+      ).toEqual({
+         content: [
+            {
+               type: "text",
+               text: '{"ok":true,"message":"hi from get"}',
+            },
+         ],
+      });
+
+      expect(
+         await client.callTool({
+            name: "another",
+            arguments: { query: "hello" },
+         })
+      ).toEqual({
+         content: [
+            {
+               type: "text",
+               text: '{"ok":true,"message":"query: hello"}',
+            },
+         ],
+      });
+
+      expect(
+         await client.callTool({
+            name: "path",
+            arguments: { name: "world" },
+         })
+      ).toEqual({
+         content: [
+            {
+               type: "text",
+               text: '{"ok":true,"message":"path: world"}',
+            },
+         ],
+      });
+
+      expect(
+         await client.callTool({
+            name: "path",
+            arguments: { name: "error" },
+         })
+      ).toEqual({
+         content: [
+            {
+               type: "text",
+               text: 'Error: {"ok":false,"error":"error"}',
+            },
+         ],
+         isError: true,
+      });
+   });
+
+   test("tools details", async () => {
+      const hono = new Hono().get(
+         "/",
+         mcpTool("get", {
+            title: "MCP GET",
+            description: "MCP GET description",
+            annotations: {
+               destructiveHint: true,
+            },
+         }),
+         (c) => c.json({ ok: true, message: "hi from get" })
+      );
+
+      const server = getMcpServer(hono);
+      expect(server.toJSON().tools[0]).toEqual({
+         name: "get",
+         title: "MCP GET",
+         description: "MCP GET description",
+         inputSchema: {
+            type: "object",
+         },
+         outputSchema: undefined,
+         annotations: {
+            destructiveHint: true,
+         },
+      });
+   });
+});

--- a/src/mcp/hono/mcp-features.middleware.ts
+++ b/src/mcp/hono/mcp-features.middleware.ts
@@ -1,0 +1,286 @@
+import type { Env, MiddlewareHandler, ValidationTargets } from "hono/types";
+import { Tool, type ToolConfig } from "../tool";
+import { type ResourceConfig, type TResourceUri } from "../resource";
+import type { Hono } from "hono";
+import { info, type RouteInfo } from "jsonv-ts/hono";
+import { invariant, isSchema, s, Schema, type ObjectSchema } from "jsonv-ts";
+import { McpServer } from "../server";
+import { mcp, type McpOptionsBase } from "./mcp.middleware";
+
+const $symbol = Symbol("mcp-feature");
+
+export type McpFeatureTool = {
+   type: "tool";
+   tool: {
+      name: string;
+      config: ToolConfig;
+   };
+};
+
+export type McpFeatureResource = {
+   type: "resource";
+   resource: {
+      name: string;
+      uri: TResourceUri;
+      config: ResourceConfig;
+   };
+};
+
+export type McpFeature = McpFeatureTool | McpFeatureResource;
+
+export type McpFeatureWithRouteInfo<T extends McpFeature = McpFeature> = T & {
+   info: RouteInfo<{ skipOpenAPI: true; useSchemas: true }>;
+   path: string;
+};
+
+export const mcpTool = <E extends Env, P extends string>(
+   name: string,
+   config: ToolConfig = {}
+) => {
+   const handler: MiddlewareHandler<E, P> = async (c, next) => {
+      await next();
+   };
+
+   return Object.assign(handler, {
+      [$symbol]: {
+         type: "tool",
+         tool: {
+            name,
+            config,
+         },
+      },
+   });
+};
+
+export const mcpResource = <E extends Env, P extends string>(
+   name: string,
+   uri: TResourceUri,
+   config: ResourceConfig = {}
+) => {
+   const handler: MiddlewareHandler<E, P> = async (c, next) => {
+      await next();
+   };
+
+   return Object.assign(handler, {
+      [$symbol]: {
+         type: "resource",
+         resource: {
+            name,
+            uri,
+            config,
+         },
+      },
+   });
+};
+
+// copied from hono src/client/utils.ts
+export const replaceUrlParam = (
+   urlString: string,
+   params: Record<string, string | undefined>
+) => {
+   for (const [k, v] of Object.entries(params)) {
+      const reg = new RegExp("/:" + k + "(?:{[^/]+})?\\??");
+      urlString = urlString.replace(reg, v ? `/${v}` : "");
+   }
+   return urlString;
+};
+
+export function infoValidationTargetsToSchema(
+   validation: Partial<Record<keyof ValidationTargets, ObjectSchema>> = {}
+) {
+   const count = Object.values(validation || {}).length;
+   if (count === 0) return undefined;
+
+   //const schemas = Object.values(validation || {});
+   const schemas = Object.entries(validation || {}).reduce((acc, [k, v]) => {
+      if (v.type === "object") {
+         for (const [, v2] of Object.entries(v.properties || {})) {
+            // @ts-ignore
+            v2.$target = k;
+         }
+      }
+
+      acc.push(v);
+      return acc;
+   }, [] as Schema[]);
+
+   return s.allOf(schemas) as ObjectSchema;
+}
+
+export function payloadToValidationTargetPayload(
+   payload: object,
+   schema: Schema
+) {
+   invariant(isSchema(schema), "schema must be a schema", schema);
+   invariant(
+      schema.type === "object",
+      "schema must be an object schema",
+      schema
+   );
+
+   const props = (schema as ObjectSchema).properties;
+   return Object.fromEntries(
+      Object.entries(props).map(([k, v]) => {
+         // @ts-ignore
+         const target = v.$target;
+         invariant(target, "target must be a string", v);
+         return [
+            target,
+            {
+               [k]: payload[k],
+            },
+         ];
+      })
+   ) as Partial<Record<keyof ValidationTargets, Record<string, any>>>;
+}
+
+export function featureInfoToRequest(
+   feature: McpFeatureWithRouteInfo,
+   params: any
+) {
+   const inputSchema = infoValidationTargetsToSchema(feature.info.validation);
+   const targets = inputSchema
+      ? payloadToValidationTargetPayload(params, inputSchema)
+      : {};
+
+   const url = new URL("https://localhost");
+   const method = feature.info.methods[0] ?? "GET";
+   const headers: Record<string, string> = {};
+   const searchParams: Record<string, string> = {};
+   let body: any = undefined;
+
+   url.pathname = targets.param
+      ? replaceUrlParam(feature.path, targets.param)
+      : feature.path;
+
+   if (targets.query) {
+      for (const [k, v] of Object.entries(targets.query)) {
+         searchParams[k] = v;
+      }
+   }
+
+   if (["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
+      if (targets.json) {
+         headers["content-type"] = "application/json";
+         body = JSON.stringify(targets.json);
+      } else if (targets.form) {
+         body = new FormData();
+         for (const [k, v] of Object.entries(targets.form)) {
+            body.append(k, v);
+         }
+      }
+   } else if (method === "GET") {
+      if (targets.form) {
+         headers["content-type"] = "application/x-www-form-urlencoded";
+         for (const [k, v] of Object.entries(targets.form)) {
+            searchParams[k] = v;
+         }
+      }
+   }
+
+   if (targets.header) {
+      for (const [k, v] of Object.entries(targets.header)) {
+         headers[k] = v;
+      }
+   }
+
+   url.search = new URLSearchParams(searchParams).toString();
+
+   // @todo: cookies
+
+   return new Request(url.toString(), {
+      method,
+      headers,
+      body,
+   });
+}
+
+export function getMcpFeatures(hono: Hono<any>) {
+   const opts = { skipOpenAPI: true, useSchemas: true };
+   const details = info(hono, opts);
+   const features: McpFeatureWithRouteInfo[] = [];
+
+   for (const route of hono.routes) {
+      if ($symbol in route.handler) {
+         const feature = route.handler[$symbol] as McpFeature;
+         const routeDetails = details[route.path];
+
+         if (!routeDetails || !routeDetails.handler) {
+            throw new Error(`Route ${route.path} has no handler`);
+         }
+
+         // @todo: check if there are validation key overlaps
+
+         features.push({
+            ...feature,
+            path: route.path,
+            info: routeDetails as any,
+         });
+      }
+   }
+
+   return features;
+}
+
+export function getMcpServer(hono: Hono<any>) {
+   const features = getMcpFeatures(hono);
+   const server = new McpServer();
+
+   for (const feature of features) {
+      if (feature.type === "tool") {
+         const inputSchema = infoValidationTargetsToSchema(
+            feature.info.validation
+         );
+
+         const tool = new Tool(
+            feature.tool.name,
+            {
+               ...feature.tool.config,
+               inputSchema,
+            },
+            async (params, c) => {
+               const request = featureInfoToRequest(feature, params);
+               const response = await hono.request(request);
+               if (!response.ok) {
+                  let error = `HTTP ${response.status} ${response.statusText}`;
+                  try {
+                     const json = await response.json();
+                     if (json) {
+                        error = JSON.stringify(json);
+                     }
+                  } catch (e) {}
+
+                  throw new Error(error);
+               }
+
+               if (
+                  response.headers
+                     .get("content-type")
+                     ?.includes("application/json")
+               ) {
+                  return c.json(await response.json());
+               }
+
+               return c.text(await response.text());
+            }
+         );
+
+         server.addTool(tool);
+      }
+   }
+
+   return server;
+}
+
+export function withMcp<H extends Hono<any>>(
+   hono: H,
+   opts: Omit<McpOptionsBase, "server"> = {}
+) {
+   const server = getMcpServer(hono);
+   return hono.use(
+      mcp({
+         server,
+         ...opts,
+      })
+   );
+}

--- a/src/mcp/hono/mcp.middleware.ts
+++ b/src/mcp/hono/mcp.middleware.ts
@@ -4,9 +4,9 @@ import {
    McpServer,
    type LogLevel,
    type McpServerInfo,
-} from "./server";
-import type { Tool } from "./tool";
-import type { Resource } from "./resource";
+} from "../server";
+import type { Tool } from "../tool";
+import type { Resource } from "../resource";
 
 export type McpServerInit =
    | {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -24,7 +24,7 @@ export {
    type McpOptionsBase,
    type McpOptionsSetup,
    type McpOptionsStatic,
-} from "./middleware";
+} from "./hono/mcp.middleware";
 export {
    type RpcMessage,
    type RpcNotification,
@@ -33,3 +33,12 @@ export {
    type TRpcResponse,
 } from "./rpc";
 export { McpClient, type McpClientConfig } from "./client";
+export {
+   mcpTool,
+   mcpResource,
+   getMcpServer,
+   withMcp,
+   type McpFeatureTool,
+   type McpFeatureResource,
+   type McpFeatureWithRouteInfo,
+} from "./hono/mcp-features.middleware";

--- a/src/mcp/messages/completion.message.ts
+++ b/src/mcp/messages/completion.message.ts
@@ -1,7 +1,6 @@
 import * as s from "jsonv-ts";
 import { RpcMessage, type TRpcRequest } from "../rpc";
 import { McpError } from "../error";
-import { isPlainObject } from "../utils";
 
 // currently just a placeholder to prevent errors
 

--- a/src/mcp/messages/index.ts
+++ b/src/mcp/messages/index.ts
@@ -1,13 +1,39 @@
-export {
+import {
    InitializeMessage,
    InitializedNotificationMessage,
 } from "./initialize.message";
-export { PingMessage } from "./ping.message";
-export { ToolsListMessage, ToolsCallMessage } from "./tools.message";
-export {
+import { PingMessage } from "./ping.message";
+import { ToolsListMessage, ToolsCallMessage } from "./tools.message";
+import {
    ResourcesListMessage,
    ResourcesTemplatesListMessage,
    ResourcesReadMessage,
 } from "./resources.message";
-export { CompletionMessage } from "./completion.message";
-export { LoggingMessage } from "./logging.message";
+import { CompletionMessage } from "./completion.message";
+import { LoggingMessage } from "./logging.message";
+
+export const messages = {
+   InitializeMessage,
+   InitializedNotificationMessage,
+   PingMessage,
+   ToolsListMessage,
+   ToolsCallMessage,
+   ResourcesListMessage,
+   ResourcesTemplatesListMessage,
+   ResourcesReadMessage,
+   CompletionMessage,
+   LoggingMessage,
+};
+
+export {
+   InitializeMessage,
+   InitializedNotificationMessage,
+   PingMessage,
+   ToolsListMessage,
+   ToolsCallMessage,
+   ResourcesListMessage,
+   ResourcesTemplatesListMessage,
+   ResourcesReadMessage,
+   CompletionMessage,
+   LoggingMessage,
+};

--- a/src/mcp/messages/initialize.message.ts
+++ b/src/mcp/messages/initialize.message.ts
@@ -1,10 +1,5 @@
 import * as s from "jsonv-ts";
-import {
-   RpcMessage,
-   RpcNotification,
-   type TRpcId,
-   type TRpcRequest,
-} from "../rpc";
+import { RpcMessage, RpcNotification, type TRpcRequest } from "../rpc";
 
 export class InitializeMessage extends RpcMessage {
    method = "initialize";

--- a/src/mcp/messages/tools.message.ts
+++ b/src/mcp/messages/tools.message.ts
@@ -1,6 +1,6 @@
 import * as s from "jsonv-ts";
 import { McpError } from "../error";
-import { RpcMessage, type TRpcMessageResult, type TRpcRequest } from "../rpc";
+import { RpcMessage, type TRpcRequest } from "../rpc";
 
 export class ToolsListMessage extends RpcMessage {
    method = "tools/list";

--- a/src/mcp/resource.ts
+++ b/src/mcp/resource.ts
@@ -73,8 +73,8 @@ export type ResourceResponse = {
 );
 
 export class Resource<
-   Name extends string,
-   Uri extends TResourceUri,
+   Name extends string = string,
+   Uri extends TResourceUri = TResourceUri,
    Context extends object = {},
    Params = Uri extends TResourceUri ? ExtractParams<Uri> : never
 > {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,4 +1,4 @@
-import * as messages from "./messages";
+import { messages } from "./messages";
 import type { RpcMessage, TRpcId, TRpcRawRequest, TRpcResponse } from "./rpc";
 import * as s from "jsonv-ts";
 import { Tool, type ToolConfig, type ToolHandler } from "./tool";
@@ -211,6 +211,14 @@ export class McpServer<
             status: 500,
          });
       }
+   }
+
+   toJSON() {
+      return {
+         serverInfo: this.serverInfo,
+         tools: this.tools.map((t) => t.toJSON()),
+         resources: this.resources.map((r) => r.toJSON()),
+      };
    }
 }
 

--- a/src/mcp/tool.ts
+++ b/src/mcp/tool.ts
@@ -59,15 +59,18 @@ export type ToolHandler<
 ) => Promise<ToolResponse>;
 
 export type ToolHandlerCtx<Context extends object = object> = {
-   text: (text: string) => any;
-   json: (json: object) => any;
+   text: (text: string) => ToolResponseText;
+   json: (json: object) => ToolResponseText;
    context: Context;
    request: Request;
 };
 
-export type ToolResponse = {
-   type: string;
+export type ToolResponseText = {
+   type: "text";
+   text: string;
 };
+
+export type ToolResponse = ToolResponseText;
 
 export class Tool<
    Name extends string = string,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,9 @@
       "rootDir": "src",
       "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
       "paths": {
-         "jsonv-ts": ["./src/lib/index.ts"]
+         "jsonv-ts": ["./src/lib/index.ts"],
+         "jsonv-ts/hono": ["./src/hono/index.ts"],
+         "jsonv-ts/mcp": ["./src/mcp/index.ts"]
       }
    },
    "include": ["src/**/*.ts"],


### PR DESCRIPTION
This allows adding MCP tools and resources from hono routes:

```ts
const hono = new Hono()
  .get("/", mcpTool("get"), (c) => c.json({ ok: true, message: "hi from get" }))
  .get(
    "/another",
    mcpTool("another"),
    validator("query", s.object({ query: s.string() })),
    (c) =>
      c.json({
        ok: true,
        message: `query: ${c.req.valid("query").query}`,
      })
  )
  .get(
    "/path/:name",
    mcpTool("path"),
    validator("param", s.object({ name: s.string() })),
    async (c) => {
      const name = c.req.valid("param").name;
      if (name === "error") {
        return c.json(
          {
            ok: false,
            error: "error",
          },
          400
        );
      }

      return c.json({
        ok: true,
        message: `path: ${name}`,
      });
    }
  );

// either get the mcp server like this
const server = getMcpServer(hono);

// or mcp-ify your hono instance
export default withMcp(hono, { endpoint: { path: "/sse" }});
```

Use it with any spec compliant MCP client or the built-in one:
```ts
const client = new McpClient({
  url: "http://localhost/sse"
});

console.log(await client.listTools());
// {
//   tools: [
//     {
//       name: "get",
//       inputSchema: {
//         type: "object",
//       },
//     }, {
//       name: "another",
//       inputSchema: {
//         type: "object",
//         required: [ "query" ],
//         properties: {
//           query: {
//             type: "string",
//             $target: "query",
//           },
//         },
//       },
//     }, {
//       name: "path",
//       inputSchema: {
//         type: "object",
//         required: [ "name" ],
//         properties: {
//           name: {
//             type: "string",
//             $target: "param",
//           },
//         },
//       },
//     }
//   ],
// }

// call "get" tool
console.log(await client.callTool({ name: "get" });
// {
//   content: [
//     {
//        type: "text",
//        text: '{"ok":true,"message":"query: hello"}',
//     },
//   ],
// }
```