### PR TITLE
ci: update pinned action versions

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,12 +27,12 @@ jobs:
       if: ${{ github.event.label.name == 'publish-preview' }}
       runs-on: ubuntu-latest
       steps:
-         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+         - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
            with:
               fetch-depth: 0
 
          - name: Setup Node.js
-           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+           uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
            with:
               node-version: "24"
 
@@ -79,12 +79,12 @@ jobs:
       needs: validate
       runs-on: ubuntu-latest
       steps:
-         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+         - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
            with:
               fetch-depth: 0
 
          - name: Setup Node.js
-           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+           uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
            with:
               node-version: "24"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,12 @@ jobs:
          contents: write
          pull-requests: write
       steps:
-         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+         - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
            with:
               fetch-depth: 0
 
          - name: Setup Node.js
-           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+           uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
            with:
               node-version: "24"
 
@@ -156,12 +156,12 @@ jobs:
          tag: ${{ steps.version.outputs.tag }}
          npm_exists: ${{ steps.target.outputs.npm_exists }}
       steps:
-         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+         - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
            with:
               fetch-depth: 0
 
          - name: Setup Node.js
-           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+           uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
            with:
               node-version: "24"
               registry-url: ${{ env.NPM_REGISTRY }}
@@ -253,7 +253,7 @@ jobs:
 
          - name: Upload package artifact
            if: ${{ steps.target.outputs.npm_exists != 'true' }}
-           uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+           uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
            with:
               name: release-package-${{ steps.version.outputs.version }}
               path: ${{ runner.temp }}/release-pack/*.tgz
@@ -269,12 +269,12 @@ jobs:
          contents: write
          id-token: write
       steps:
-         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+         - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
            with:
               fetch-depth: 0
 
          - name: Setup Node.js
-           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+           uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
            with:
               node-version: "24"
               registry-url: ${{ env.NPM_REGISTRY }}
@@ -319,7 +319,7 @@ jobs:
 
          - name: Download package artifact
            if: ${{ needs.validate-stable.outputs.npm_exists != 'true' }}
-           uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+           uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
            with:
               name: release-package-${{ needs.validate-stable.outputs.version }}
               path: ${{ runner.temp }}/release-pack
@@ -372,12 +372,12 @@ jobs:
          version: ${{ steps.version.outputs.version }}
          tag: ${{ steps.version.outputs.tag }}
       steps:
-         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+         - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
            with:
               fetch-depth: 0
 
          - name: Setup Node.js
-           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+           uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
            with:
               node-version: "24"
               registry-url: ${{ env.NPM_REGISTRY }}
@@ -509,7 +509,7 @@ jobs:
               fi
 
          - name: Upload package artifact
-           uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+           uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
            with:
               name: release-package-${{ steps.version.outputs.version }}
               path: ${{ runner.temp }}/release-next-pack/*.tgz
@@ -525,18 +525,18 @@ jobs:
          contents: write
          id-token: write
       steps:
-         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+         - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
            with:
               fetch-depth: 0
 
          - name: Setup Node.js
-           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+           uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
            with:
               node-version: "24"
               registry-url: ${{ env.NPM_REGISTRY }}
 
          - name: Download package artifact
-           uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+           uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
            with:
               name: release-package-${{ needs.validate-next.outputs.version }}
               path: ${{ runner.temp }}/release-next-pack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
       runs-on: ubuntu-latest
 
       steps:
-         - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+         - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
          - name: Setup Node.js
-           uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+           uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
            with:
               node-version: "22.x"
 


### PR DESCRIPTION
Updates pinned GitHub Actions to newer SHA-pinned versions so workflows no longer warn about Node.js 20 action runtimes being forced onto Node 24.
Keeps every action pinned to a full commit SHA while bumping checkout/setup-node and artifact upload/download actions.
Validated workflow YAML parsing, whitespace checks, and a scan for unpinned action refs.
